### PR TITLE
TreeListBox: Check items when removing.

### DIFF
--- a/Source/PropertyTools.Wpf/TreeListBox/TreeListBox.cs
+++ b/Source/PropertyTools.Wpf/TreeListBox/TreeListBox.cs
@@ -636,19 +636,22 @@ namespace PropertyTools.Wpf
             while (queue.Count > 0)
             {
                 var item = queue.Dequeue();
-                if (this.isExpanded[item])
+                if (this.Items.Contains(item))
                 {
-                    IList children;
-                    if (this.itemToChildrenMap.TryGetValue(item, out children) && children != null)
+                    if (this.isExpanded[item])
                     {
-                        foreach (var child in children)
+                        IList children;
+                        if (this.itemToChildrenMap.TryGetValue(item, out children) && children != null)
                         {
-                            queue.Enqueue(child);
+                            foreach (var child in children)
+                            {
+                                queue.Enqueue(child);
+                            }
                         }
                     }
-                }
 
-                this.RemoveItem(item);
+                    this.RemoveItem(item);
+                }
             }
         }
 


### PR DESCRIPTION
OTD 9734: No clear error message when importing old js file.

The item will not be added into TreeList if the property isExpanded of
its parent is false. Then we will get error if we try to remove this
item(from script).