### PR TITLE
Added "Windows Phone 8.1" as target of the portable class library "Prope...

### DIFF
--- a/Source/PropertyTools/PropertyTools_PCL.csproj
+++ b/Source/PropertyTools/PropertyTools_PCL.csproj
@@ -11,7 +11,7 @@
     <RootNamespace>PropertyTools</RootNamespace>
     <AssemblyName>PropertyTools</AssemblyName>
     <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
-    <TargetFrameworkProfile>Profile136</TargetFrameworkProfile>
+    <TargetFrameworkProfile>Profile328</TargetFrameworkProfile>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
   </PropertyGroup>


### PR DESCRIPTION
I needed this change in order to use PropertyTools within a UniversalApp which also targets Windows Phone 8.1