### PR TITLE
Fix a potential leak.

### DIFF
--- a/Source/PropertyTools.Wpf/TreeListBox/TreeListBox.cs
+++ b/Source/PropertyTools.Wpf/TreeListBox/TreeListBox.cs
@@ -667,6 +667,7 @@ namespace PropertyTools.Wpf
             this.itemToChildrenMap.Clear();
             this.childrenToItemMap.Clear();
             this.itemLevelMap.Clear();
+            this.isExpanded.Clear();
         }
 
         /// <summary>


### PR DESCRIPTION
The isExpanded will hold the element and prevent it from being GCed.
It causes memory leak. 