### PR TITLE
Added ability to resize rows

### DIFF
--- a/Source/PropertyTools.Wpf/DataGrid/Definitions/RowDefinition.cs
+++ b/Source/PropertyTools.Wpf/DataGrid/Definitions/RowDefinition.cs
@@ -10,6 +10,7 @@
 namespace PropertyTools.Wpf
 {
     using System.ComponentModel;
+    using System.Windows;
 
     /// <summary>
     /// Defines row-specific properties that apply to <see cref="DataGrid" /> elements.
@@ -20,7 +21,8 @@ namespace PropertyTools.Wpf
         /// Initializes a new instance of the <see cref="RowDefinition"/> class.
         /// </summary>
         public RowDefinition()
-        {            
+        {
+            this.Height = GridLength.Auto;
         }
 
         /// <summary>
@@ -29,6 +31,13 @@ namespace PropertyTools.Wpf
         /// <param name="descriptor">The property descriptor.</param>
         public RowDefinition(PropertyDescriptor descriptor) : base(descriptor)
         {
+            this.Height = GridLength.Auto;
         }
+
+        /// <summary>
+        /// Gets or sets the row height.
+        /// </summary>
+        /// <value>The height.</value>
+        public GridLength Height { get; set; }
     }
 }


### PR DESCRIPTION
We needed the ability to resize the rows in addition to the columns, so this code basically replicates the column resizing logic for the rows. Resizing for the rows is enabled by default, so this will change existing functionality, but as resizing rows is something that you would normally expect from an Excel-like grid I felt this was better than defaulting to off. Since the code is largely copied from the columns, the functionality works the same way as the column resizing, namely with a "Height" tooltip on resize and double click to auto-size. I didn't add an example since this functionality essentially affects all of the examples, but if you think a separate one would be of use I'd be happy to add it. Let me know what you think!