### PR TITLE
Improved paste speed by removing repetitive UpdateGridContent calls

### DIFF
--- a/Source/PropertyTools.Wpf/DataGrid/DataGrid.cs
+++ b/Source/PropertyTools.Wpf/DataGrid/DataGrid.cs
@@ -1970,11 +1970,13 @@ namespace PropertyTools.Wpf
             int rows = values.GetUpperBound(0) + 1;
             int columns = values.GetUpperBound(1) + 1;
 
+            UnsubscribeNotifications();
+
             for (int i = rowMin; i <= rowMax || i < rowMin + rows; i++)
             {
                 if (i >= this.Rows)
                 {
-                    if (!this.InsertItem(-1))
+                    if (!this.InsertItem(-1, false))
                     {
                         break;
                     }
@@ -1986,6 +1988,8 @@ namespace PropertyTools.Wpf
                     this.TrySetCellValue(new CellRef(i, j), value);
                 }
             }
+
+            UpdateGridContent();
 
             this.CurrentCell = new CellRef(rowMin, columnMin);
             this.SelectionCell = new CellRef(


### PR DESCRIPTION
When pasting data, especially large amounts, the DataGrid would take an extremely long time to finish, and if the data pasted was large enough, appear to freeze. You can replicate this by going to any of the demos that support pasting (I used List<List<int>>) and pasting a large amount of lines. The time it takes to complete this operation can easily take multiple seconds (or even minutes) depending on the size of the table before pasting and the amount of data pasted.

This was caused by the Paste method calling UpdateGridContent() once directly as a result of the InsertItem(...) call and once as a result of the CollectionChanged event if the underlying collection supports it. Each UpdateGridContent() call refreshes the entire contents of the grid control meaning this issue can compound pretty quickly.

The fix is pretty simple. Before the paste begins I unsubscribe from the CollectionChanged event, if applicable, don't update the grid on each insertion, and then at the end of the paste make a single call to UpdateGridContent() (This call resubscribes which is why the Paste method itself doesn't).

Granted, it should be possible to only update the grid to specifically add the rows/columns that were inserted by the paste instead of regenerating the entire control, but this should probably be part of a larger change that would affect multiple areas such as OnItemsSourceChanged, column insertion, row insertion, etc.