### PR TITLE
PropertyDefinition Descriptor Bug

### DIFF
--- a/Source/PropertyTools.Wpf/DataGrid/Definitions/PropertyDefinition.cs
+++ b/Source/PropertyTools.Wpf/DataGrid/Definitions/PropertyDefinition.cs
@@ -265,7 +265,20 @@ namespace PropertyTools.Wpf
         /// <param name="itemType">Type of the items.</param>
         public void UpdateDescriptor(Type itemType)
         {
-            this.Descriptor = TypeDescriptor.GetProperties(itemType)[this.PropertyName];
+            var descriptor = TypeDescriptor.GetProperties(itemType)[this.PropertyName];
+            this.Descriptor = descriptor;
+
+            this.IsReadOnly = this.IsReadOnly || (descriptor != null && descriptor.IsReadOnly);
+            if (descriptor != null)
+            {
+                this.PropertyType = descriptor.PropertyType;
+            }
+
+            var ispa = this.GetFirstAttribute<ItemsSourcePropertyAttribute>();
+            if (ispa != null)
+            {
+                this.ItemsSourceProperty = ispa.PropertyName;
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
Commit f38925b7 on 3/7/2016 made a change to the PropertyDescriptor in PropertyDefinition, removing the setter and replacing it with the UpdateDescriptor(...) method. This method didn't update the IsReadOnly, PropertyType, and ItemsSourceProperty properties on the PropertyDefinition causing issues elsewhere.

The case that prompted this change was a pasting failure because the PropertyType property on the PropertyDefinition was a container class rather than the expected System.Double (the PropertyName setting was set) causing a conversion failure from the pasted string value. This can be seen in the demo application on the "ObservableCollection<ExampleObject> (custom columns)" demo where all paste operations will fail.

The fix adds what was formerly in the Descriptor setter to the UpdateDescriptor(...) method.