### PR TITLE
[DataGridDemo] Implement IComparable on Mass object to allow sorting

### DIFF
--- a/Source/Examples/DataGrid/DataGridDemo/DataTypes/Mass.cs
+++ b/Source/Examples/DataGrid/DataGridDemo/DataTypes/Mass.cs
@@ -9,7 +9,7 @@ namespace DataGridDemo
     using System;
     using System.Text.RegularExpressions;
 
-    public struct Mass
+    public struct Mass : IComparable<Mass>, IComparable
     {
         public static Mass Kilogram = new Mass(1);
         public static Mass Gram = new Mass(1e-3);
@@ -26,6 +26,20 @@ namespace DataGridDemo
         public override string ToString()
         {
             return value + " kg";
+        }
+
+        public int CompareTo(Mass that)
+        {
+            return this.value.CompareTo(that.value);
+        }
+
+        public int CompareTo(object obj)
+        {
+            if (obj != null && obj is Mass)
+            {
+                return CompareTo((Mass)obj);
+            }
+            throw new ArgumentException("Object is not of type Mass");
         }
 
         public static Mass operator +(Mass x, Mass y)


### PR DESCRIPTION
Without implementing IComparable an InvalidOperationEception (Failed to compare two elements in the array) is thrown when attempting to sort by a column displaying `Mass`. You can trigger the exception by starting the `List<Mass>` example and clicking on the header to sort.

I went ahead and implemented both IComparable and IComparable<T>.